### PR TITLE
Adding in .Net 8 as target

### DIFF
--- a/Maui.ColorPicker/Maui.ColorPicker.csproj
+++ b/Maui.ColorPicker/Maui.ColorPicker.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->


### PR DESCRIPTION
Made an issue a little while back that was saying that not having .net8.0 as a target was fighting with making things unit testable, thought I had figured out a solution, turns out I hadn't.

Adding this as a target doesn't change the compilation at all and would really help me out.