### PR TITLE
Add TouchActionType property to select color on touch up

### DIFF
--- a/Maui.ColorPicker.Demo/MainPage.xaml
+++ b/Maui.ColorPicker.Demo/MainPage.xaml
@@ -51,6 +51,7 @@
                                       ColorSpectrumStyle="TintToHueToShadeStyle"
                                       PickedColorChanged="ColorPicker_PickedColorChanged"
                                       PickedColor="IndianRed"
+									  TouchActionType="OnTouchUp"
                                       PointerRingBorderUnits="0.3"
                                       PointerRingDiameterUnits="0.7">
                     <controls:ColorPicker.BaseColorList>

--- a/Maui.ColorPicker/ColorPicker.xaml.cs
+++ b/Maui.ColorPicker/ColorPicker.xaml.cs
@@ -281,6 +281,25 @@ public partial class ColorPicker : ContentView
             });
 
     /// <summary>
+    /// Gets or sets the type of touch action that triggers the color selection.
+    /// </summary>
+    /// <value>
+    /// The type of touch action. The default is <see cref="TouchActionType.OnTouchDown"/>.
+    /// </value>
+    public TouchActionType TouchActionType
+    {
+        get => (TouchActionType)GetValue(TouchActionTypeProperty);
+        set => SetValue(TouchActionTypeProperty, value);
+    }
+
+    public static readonly BindableProperty TouchActionTypeProperty =
+    BindableProperty.Create(
+        nameof(TouchActionType),
+        typeof(TouchActionType),
+        typeof(ColorPicker),
+        TouchActionType.OnTouchDown);
+
+    /// <summary>
     /// Sets the Picker Pointer Y position
     /// Value must be between 0-1
     /// Calculated against the View Canvas Width value
@@ -393,8 +412,11 @@ public partial class ColorPicker : ContentView
                 touchPointColor = bitmap.GetPixel(0, 0);
             }
 
-            // Set selected color
-            SetValue(PickedColorProperty, touchPointColor.ToMauiColor());
+            // Set selected color on touch down or prepare the pending color for touch up
+            if (TouchActionType == TouchActionType.OnTouchUp)
+                _pendingPickedColor = touchPointColor.ToMauiColor();
+            else
+                SetValue(PickedColorProperty, touchPointColor.ToMauiColor());
         }
         else
         {
@@ -499,7 +521,14 @@ public partial class ColorPicker : ContentView
         if (!e.InContact)
             return;
 #endif
-
+        // Select the pending color if set to do so on touch up
+        if (TouchActionType == TouchActionType.OnTouchUp
+            && e.ActionType == SKTouchAction.Released
+            && _pendingPickedColor != null)
+        {
+            SetValue(PickedColorProperty, _pendingPickedColor);
+            return;
+        }
 
         var canvasSize = CanvasView.CanvasSize;
 
@@ -594,4 +623,10 @@ public enum ColorFlowDirection
 {
     Horizontal,
     Vertical
+}
+
+public enum TouchActionType
+{
+    OnTouchDown,
+    OnTouchUp
 }

--- a/Maui.ColorPicker/ColorPicker.xaml.cs
+++ b/Maui.ColorPicker/ColorPicker.xaml.cs
@@ -36,6 +36,7 @@ public partial class ColorPicker : ContentView
             typeof(ColorPicker),
             propertyChanged: (bindable, value, newValue) =>
             {
+                if (newValue is null) return;
                 if (!newValue.Equals(value) && (bindable is ColorPicker picker))
                 {
                     picker.PickedColorChanged?
@@ -519,7 +520,13 @@ public partial class ColorPicker : ContentView
     {
 #if WINDOWS
         if (!e.InContact)
-            return;
+        {
+            if (TouchActionType == TouchActionType.OnTouchUp)
+            {
+                SetValue(PickedColorProperty, _pendingPickedColor);
+            }
+		    return;
+        }
 #endif
         // Select the pending color if set to do so on touch up
         if (TouchActionType == TouchActionType.OnTouchUp

--- a/Maui.ColorPicker/Maui.ColorPicker.csproj
+++ b/Maui.ColorPicker/Maui.ColorPicker.csproj
@@ -16,9 +16,9 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<AssemblyVersion>2.0.0</AssemblyVersion>
-		<AssemblyFileVersion>2.0.0</AssemblyFileVersion>
-		<Version>2.0.0</Version>
+		<AssemblyVersion>2.0.1</AssemblyVersion>
+		<AssemblyFileVersion>2.0.1</AssemblyFileVersion>
+		<Version>2.0.1</Version>
 		<Title>nor0x.Maui.ColorPicker</Title>
 		<PackageId>nor0x.Maui.ColorPicker</PackageId>
 		<PackageReleaseNotes>https://github.com/nor0x/Maui.ColorPicker/releases</PackageReleaseNotes>


### PR DESCRIPTION
Introduced a new TouchActionType property to allow color selection using a touch up action, in addition to the default touch down action. This can be set in the XAML as `TouchActionType="OnTouchUp"`